### PR TITLE
Add named method for BoolExpr

### DIFF
--- a/logicdsl/__init__.py
+++ b/logicdsl/__init__.py
@@ -5,14 +5,21 @@ Public surface of the LogicDSL package.
 
 from .constraints import (at_least_one, at_most_one, distinct, exactly_one, exists, forall)
 from .core import BoolExpr, BoolVar, Expr, Var
+
+
+def named(expr: BoolExpr, name: str) -> BoolExpr:
+        """Return a BoolExpr with the provided name."""
+        return expr.named(name)
+
 from .solver import LogicSolver, Soft
 
 __all__ = [
 	"Var",
 	"BoolVar",
 	"Expr",
-	"BoolExpr",
-	# constraints
+        "BoolExpr",
+        "named",
+        # constraints
 	"distinct",
 	"at_least_one",
 	"at_most_one",

--- a/logicdsl/core.py
+++ b/logicdsl/core.py
@@ -143,7 +143,11 @@ class BoolExpr:
 	def __rshift__(self, o):
 		o = BoolExpr._B(o)
 		return BoolExpr(lambda a, s=self, t=o: (not s.satisfied(a)) or t.satisfied(a))
-	
+
+	def named(self, name: str) -> "BoolExpr":
+		"""Return a copy of this BoolExpr with a different name."""
+		return BoolExpr(self._f, name)
+
 	def __repr__(self) -> str:
 		return f"BoolExpr({self.name})"
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -84,3 +84,9 @@ def test_quantifiers():
 	# exists xs: x == 2
 	assert exists(xs, lambda v: v == 2).satisfied(assgn(x0=1, x1=2, x2=3))
 	assert not exists(xs, lambda v: v == 4).satisfied(assgn(x0=1, x1=2, x2=3))
+
+
+def test_boolexpr_named():
+	expr = (Var("x") << (1, 2)) == 1
+	named = expr.named("Xeq1")
+	assert named.name == "Xeq1"


### PR DESCRIPTION
## Summary
- add `named` method to `BoolExpr`
- expose helper `named` at package level
- export new helper in `__all__`
- test `named` method functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ddfdd6cc8327810ae04c907dce06