### PR TITLE
Add all_solutions enumeration method

### DIFF
--- a/logicdsl/solver.py
+++ b/logicdsl/solver.py
@@ -6,9 +6,10 @@ from typing import Any, Dict, List, Tuple, Set
 from .core import BoolExpr, Expr, Var
 
 
-def collect_vars(expr: Expr | BoolExpr) -> Set[Var]:
-	"""Return the set of Vars referenced in an expression tree."""
-	return set(getattr(expr, "_vars", set()))
+def collect_vars(expr: Expr | BoolExpr) -> List[Var]:
+        """Return vars referenced in an expression tree in deterministic order."""
+        vars_set: Set[Var] = set(getattr(expr, "_vars", set()))
+        return sorted(vars_set, key=lambda v: v.name)
 
 
 class Soft:
@@ -95,34 +96,61 @@ class LogicSolver:
 				return False
 		return True
 	
-	def _bt(self, idx: int, assignment: Dict[str, Any]) -> None:
-		if idx == len(self.vars):
-			score = self._score(assignment)
-			if self._better(score, self._best_score):
-				self._best_score = score
-				self._best_assignment = assignment.copy()
-				if self.trace:
-					print("NEW BEST", score, self._best_assignment)
-			return
+	def _bt(
+	        self,
+	        idx: int,
+	        assignment: Dict[str, Any],
+	        solutions: List[Dict[str, Any]] | None = None,
+	        limit: int | None = None,
+	) -> None:
+	        if solutions is not None and limit is not None and len(solutions) >= limit:
+	                return
+
+	        if idx == len(self.vars):
+	                if solutions is not None:
+	                        penalty, obj_vec = self._score(assignment)
+	                        solutions.append({
+	                                "assignment": assignment.copy(),
+	                                "penalty": penalty,
+	                                "objectives": obj_vec,
+	                        })
+	                        return
+
+	                score = self._score(assignment)
+	                if self._better(score, self._best_score):
+	                        self._best_score = score
+	                        self._best_assignment = assignment.copy()
+	                        if self.trace:
+	                                print("NEW BEST", score, self._best_assignment)
+	                return
 		
-		v = self.vars[idx]
-		for val in v.domain:
-			assignment[v.name] = val
-			if self._consistent(assignment):
-				self._bt(idx + 1, assignment)
-		assignment.pop(v.name, None)
+	        v = self.vars[idx]
+	        for val in v.domain:
+	                assignment[v.name] = val
+	                if self._consistent(assignment):
+	                        self._bt(idx + 1, assignment, solutions, limit)
+	                        if solutions is not None and limit is not None and len(solutions) >= limit:
+	                                assignment.pop(v.name, None)
+	                                return
+	        assignment.pop(v.name, None)
 	
 	def solve(self) -> Dict[str, Any]:
-		self._best_score, self._best_assignment = None, None
-		self._bt(0, {})
-		if self._best_assignment is None:
-			raise RuntimeError("No feasible solution")
-		penalty, obj_vec = self._best_score
-		return {
-			"assignment": self._best_assignment,
-			"penalty": penalty,
-			"objectives": obj_vec,
-		}
+	        self._best_score, self._best_assignment = None, None
+	        self._bt(0, {})
+	        if self._best_assignment is None:
+	                raise RuntimeError("No feasible solution")
+	        penalty, obj_vec = self._best_score
+	        return {
+	                "assignment": self._best_assignment,
+	                "penalty": penalty,
+	                "objectives": obj_vec,
+	        }
+
+	def all_solutions(self, limit: int | None = None) -> List[Dict[str, Any]]:
+	        """Return all feasible assignments up to ``limit`` solutions."""
+	        solutions: List[Dict[str, Any]] = []
+	        self._bt(0, {}, solutions, limit)
+	        return solutions
 	
 	# ───────────────────────────── convenience
 	@staticmethod

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -70,13 +70,47 @@ def test_distinct_constraint_in_solver():
 
 
 def test_unsat_raises():
-	"""
-	Impossible constraint should raise RuntimeError.
-	"""
-	x = Var("x") << {1}
-	y = Var("y") << {2}
-	S = LogicSolver()
-	S.require(x + y == 100, "impossible")
-	
-	with pytest.raises(RuntimeError):
-		S.solve()
+        """
+        Impossible constraint should raise RuntimeError.
+        """
+        x = Var("x") << {1}
+        y = Var("y") << {2}
+        S = LogicSolver()
+        S.require(x + y == 100, "impossible")
+
+        with pytest.raises(RuntimeError):
+                S.solve()
+
+
+def test_all_solutions_limit():
+        """Enumerate first two solutions to x + y == 4 with x,y in [1..3]."""
+        x = Var("x") << (1, 3)
+        y = Var("y") << (1, 3)
+
+        S = LogicSolver()
+        S.require(x + y == 4)
+
+        sols = S.all_solutions(limit=2)
+        assert len(sols) == 2
+        assert sols[0]["assignment"] == {"x": 1, "y": 3}
+        assert sols[1]["assignment"] == {"x": 2, "y": 2}
+
+
+def test_all_solutions_penalty_and_objective():
+        """Return solutions with penalties and objective values included."""
+        x = Var("x") << {0, 1}
+
+        S = LogicSolver()
+        S.prefer(x == 1, penalty=5)
+        S.maximize(x)
+
+        sols = S.all_solutions()
+        assert len(sols) == 2
+        # first assignment should be x=0 (penalty 5)
+        assert sols[0]["assignment"]["x"] == 0
+        assert sols[0]["penalty"] == 5
+        assert sols[0]["objectives"][0] == 0
+        # second assignment should be x=1 (penalty 0)
+        assert sols[1]["assignment"]["x"] == 1
+        assert sols[1]["penalty"] == 0
+        assert sols[1]["objectives"][0] == 1


### PR DESCRIPTION
## Summary
- collect multiple solutions in LogicSolver
- expose `all_solutions` API and support limit
- test enumeration order and returned penalties/objectives
- ensure variable enumeration order is deterministic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ec89f3e883278f015cfdbd96a265