### PR TITLE
Add weighted sum objective mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ print(solver.pretty(solution))
 
 Running the above prints the best assignment of `x` and `y` that sums to 10 while maximizing their product.
 
+### Objective Modes
+
+By default the solver optimizes objectives lexicographically.  To combine
+multiple objectives using a weighted sum pass ``objective_mode="sum"`` when
+creating the solver.  Each call to ``maximize``/``minimize`` accepts an optional
+``weight`` parameter used in the sum.
+
+```python
+solver = LogicSolver(objective_mode="sum")
+solver.maximize(x, weight=1)
+solver.maximize(y, weight=2)
+```
+

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -114,3 +114,28 @@ def test_all_solutions_penalty_and_objective():
 	assert sols[1]["assignment"]["x"] == 1
 	assert sols[1]["penalty"] == 0
 	assert sols[1]["objectives"][0] == 1
+
+
+def test_objective_mode_sum():
+	"""Weighted-sum objectives choose different assignment than lexicographic."""
+	x = Var("x") << {0, 1}
+	y = Var("y") << {0, 1}
+
+	constraint = sum_of([x, y]) <= 1
+
+	S_lex = LogicSolver()
+	S_lex.require(constraint)
+	S_lex.maximize(x)
+	S_lex.maximize(y)
+
+	sol_lex = S_lex.solve()
+	assert sol_lex["assignment"] == {"x": 1, "y": 0}
+
+	S_sum = LogicSolver(objective_mode="sum")
+	S_sum.require(constraint)
+	S_sum.maximize(x, weight=1)
+	S_sum.maximize(y, weight=2)
+
+	sol_sum = S_sum.solve()
+	assert sol_sum["assignment"] == {"x": 0, "y": 1}
+	assert sol_sum["objective"] == 2


### PR DESCRIPTION
## Summary
- add optional `objective_mode` to `LogicSolver`
- support `maximize`/`minimize` weights
- compute weighted-sum score when `objective_mode='sum'`
- document objective modes in README
- test lexicographic vs weighted sum objectives

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573627b2588327a8e43faa24fad4e6