### PR TITLE
Update README for automatic variable discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ x = Var("x") << (1, 9)
 y = Var("y") << {2, 4, 6, 8}
 
 solver = LogicSolver()
-solver.add_variables([x, y])
+
+# variables used in constraints are added automatically
 
 # hard constraint and optimization objective
 solver.require(x + y == 10)
@@ -31,6 +32,8 @@ print(solver.pretty(solution))
 ```
 
 Running the above prints the best assignment of `x` and `y` that sums to 10 while maximizing their product.
+
+Variables do not need to be registered explicitly; the solver automatically discovers all variables that appear in constraints or objectives.
 
 ### Objective Modes
 

--- a/examples/all_features_demo.py
+++ b/examples/all_features_demo.py
@@ -6,7 +6,7 @@ z = Var("z").in_range(0, 5)
 a, b, c = [Var(v) << (1, 3) for v in "abc"]
 
 S = LogicSolver()
-S.add_variables([x, y, z, a, b, c])
+# variables used in constraints are added automatically
 
 S.require(x + y == 10)
 S.require((x != y) & (y < 9))

--- a/logicdsl/solver.py
+++ b/logicdsl/solver.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
 	y = Var("y") << {2, 4, 6, 8}
 	
 	solver = LogicSolver(trace=True)
-	solver.add_variables([x, y])
+	# variables used in constraints are added automatically
 	solver.require(x + y == 10, "sum10")
 	solver.maximize(x * y)
 	

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ def demo():
         x = Var("x") << (1, 9)
         y = Var("y") << {2, 4, 6, 8}
         solver = LogicSolver(trace=True)
-        solver.add_variables([x, y])
+        # variables used in constraints are added automatically
         solver.require(x + y == 10, "sum10")
         solver.maximize(x * y)
         result = solver.solve()


### PR DESCRIPTION
## Summary
- remove `solver.add_variables` from README demo
- note that variables in constraints are found automatically
- update examples and internal demo code to match

## Testing
- `python examples/all_features_demo.py`
- `python main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68573e1bd03083278c335c2936f9c0da