### PR TITLE
Add quantifier classes and new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,21 @@ solver.maximize(x, weight=1)
 solver.maximize(y, weight=2)
 ```
 
+### Quantifiers
+
+`forall` and `exists` still accept a list of variables and a lambda
+function as before.  When called with only the variable list they now
+return quantifier objects that accept a predicate using `>>` or
+`.require()`.
+
+```python
+xs = [Var(f"x{i}") << (1, 3) for i in range(3)]
+
+# traditional
+forall(xs, lambda v: v <= 3)
+
+# new style
+forall(xs) >> (lambda v: v <= 3)
+exists(xs).require(lambda v: v == 2)
+```
+

--- a/logicdsl/constraints.py
+++ b/logicdsl/constraints.py
@@ -87,12 +87,42 @@ def exactly_k(xs: List[BoolExpr | Var], k: int) -> BoolExpr:
         return at_least_k(xs_b, k) & at_least_k([~x for x in xs_b], n - k)
 
 
-def forall(vs: Iterable[Var], f) -> BoolExpr:
-	return _fold_and([f(v) for v in vs])
+class ForAll:
+        """Quantifier representing conjunction over a set of variables."""
+
+        def __init__(self, vs: Iterable[Var]):
+                self.vs = list(vs)
+
+        def require(self, f) -> BoolExpr:
+                return _fold_and([f(v) for v in self.vs])
+
+        def __rshift__(self, f) -> BoolExpr:
+                return self.require(f)
 
 
-def exists(vs: Iterable[Var], f) -> BoolExpr:
-        return _fold_or([f(v) for v in vs])
+class Exists:
+        """Quantifier representing disjunction over a set of variables."""
+
+        def __init__(self, vs: Iterable[Var]):
+                self.vs = list(vs)
+
+        def require(self, f) -> BoolExpr:
+                return _fold_or([f(v) for v in self.vs])
+
+        def __rshift__(self, f) -> BoolExpr:
+                return self.require(f)
+
+
+def forall(vs: Iterable[Var], f=None) -> BoolExpr | ForAll:
+        if f is None:
+                return ForAll(vs)
+        return ForAll(vs).require(f)
+
+
+def exists(vs: Iterable[Var], f=None) -> BoolExpr | Exists:
+        if f is None:
+                return Exists(vs)
+        return Exists(vs).require(f)
 
 
 # ───────────────────────────── arithmetic helpers

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -96,6 +96,13 @@ def test_quantifiers():
 	assert not exists(xs, lambda v: v == 4).satisfied(assgn(x0=1, x1=2, x2=3))
 
 
+def test_quantifier_objects():
+	xs = [Var(f"x{i}") << (1, 3) for i in range(3)]
+	assert (forall(xs) >> (lambda v: v <= 3)).satisfied(assgn(x0=1, x1=2, x2=3))
+	assert (exists(xs).require(lambda v: v == 2)).satisfied(assgn(x0=1, x1=2, x2=3))
+	assert not (exists(xs) >> (lambda v: v == 4)).satisfied(assgn(x0=1, x1=2, x2=3))
+
+
 def test_boolexpr_named():
         expr = (Var("x") << (1, 2)) == 1
         named = expr.named("Xeq1")


### PR DESCRIPTION
## Summary
- introduce `ForAll` and `Exists` quantifier classes
- support `forall(vs) >> lambda` and `exists(vs).require(lambda)` usage
- keep existing lambda-based helpers for compatibility
- document new quantifier API in README
- test new quantifier object usage

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574448ed5c83279be8ab77299f7132