### PR TITLE
Add when(cond).then(expr) helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,15 @@ forall(xs) >> (lambda v: v <= 3)
 exists(xs).require(lambda v: v == 2)
 ```
 
+### When/Then Helper
+
+``when(cond).then(expr)`` builds an implication ``cond >> expr``.  This can make
+dynamic constructions a bit clearer.
+
+```python
+p = BoolVar("p")
+q = BoolVar("q")
+
+rule = when(p).then(q)  # equivalent to p >> q
+```
+

--- a/logicdsl/__init__.py
+++ b/logicdsl/__init__.py
@@ -22,6 +22,26 @@ def named(expr: BoolExpr, name: str) -> BoolExpr:
         """Return a BoolExpr with the provided name."""
         return expr.named(name)
 
+
+class _ImplicationBuilder:
+        """Helper object returned by :func:`when` to chain ``.then``."""
+
+        def __init__(self, cond: BoolExpr) -> None:
+                self._cond = cond
+
+        def then(self, expr: BoolExpr | Var) -> BoolExpr:
+                """Return implication ``cond >> expr``."""
+                return self._cond >> BoolExpr._B(expr)
+
+
+def when(cond: BoolExpr | Var) -> _ImplicationBuilder:
+        """Convenience builder for implication expressions.
+
+        ``when(p).then(q)`` is equivalent to ``p >> q`` but can be useful when
+        constructing conditions dynamically.
+        """
+        return _ImplicationBuilder(BoolExpr._B(cond))
+
 from .solver import LogicSolver, Soft
 
 __all__ = [
@@ -30,6 +50,7 @@ __all__ = [
 	"Expr",
         "BoolExpr",
         "named",
+        "when",
         # constraints
 	"distinct",
         "at_least_one",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,6 +13,7 @@ from logicdsl import (
         exactly_one,
         exists,
         forall,
+        when,
         sum_of,
         product_of,
 )
@@ -118,3 +119,14 @@ def test_sum_and_product_of():
 
         assert s.eval(assignment) == 6
         assert p.eval(assignment) == 6
+
+
+def test_when_then():
+        p = BoolVar("p")
+        q = BoolVar("q")
+
+        implication = when(p).then(q)
+
+        assert implication.satisfied(assgn(p=0, q=0))
+        assert implication.satisfied(assgn(p=1, q=1))
+        assert not implication.satisfied(assgn(p=1, q=0))


### PR DESCRIPTION
## Summary
- create `when(cond)` builder returning `.then(expr)`
- export helper from package
- document helper in README
- test the helper

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685746d698e0832798dea7ec96de1bd1