### PR TITLE
Extend Soft weight and scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ solver.maximize(x, weight=1)
 solver.maximize(y, weight=2)
 ```
 
+### Soft Constraints
+
+Use `prefer` to add a soft constraint with an optional penalty and weight. The
+weight influences the search when using `objective_mode="sum"`.
+
+```python
+solver.prefer(x > 5, penalty=1, weight=5.0)
+```
+
 ### Quantifiers
 
 `forall` and `exists` still accept a list of variables and a lambda

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -139,3 +139,19 @@ def test_objective_mode_sum():
 	sol_sum = S_sum.solve()
 	assert sol_sum["assignment"] == {"x": 0, "y": 1}
 	assert sol_sum["objective"] == 2
+
+
+	def test_soft_weights_with_sum_mode():
+	        """Weighted soft constraints influence tie-breaking when using sum mode."""
+	        x = Var("x") << {0, 1}
+	        y = Var("y") << {0, 1}
+	
+	        S = LogicSolver(objective_mode="sum")
+	        S.require(sum_of([x, y]) == 1)
+	        S.prefer(x == 1, penalty=1, weight=5.0)
+	        S.prefer(y == 1, penalty=1, weight=1.0)
+	
+	        sol = S.solve()
+	        assert sol["assignment"] == {"x": 1, "y": 0}
+	        assert sol["penalty"] == 1
+	        assert sol["objective"] == -1


### PR DESCRIPTION
## Summary
- add `weight` to `Soft` with `weighted_cost` helper
- include soft weights in solver sum-mode scoring
- support weighted soft constraints in API and docs
- test weighted soft constraints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857497c09d0832787f9933355b4bba3