### PR TITLE
Add abs operator support

### DIFF
--- a/logicdsl/core.py
+++ b/logicdsl/core.py
@@ -69,6 +69,8 @@ class Expr:
 	
 	def __neg__(self):
 		return Expr(lambda a, s=self: -s.eval(a), vars=self._vars)
+	def __abs__(self):
+		return self.abs()
 
 	def abs(self):
 		return Expr(lambda a, s=self: abs(s.eval(a)), vars=self._vars)
@@ -224,6 +226,8 @@ class Var:
 	
 	def __neg__(self):
 		return -self.expr
+	def __abs__(self):
+		return abs(self.expr)
 	
 	# comparisons
 	def __eq__(self, o):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,10 +36,21 @@ def test_expr_arithmetic_and_eval():
 
 
 def test_var_neg_and_abs():
-	x = Var("x") << (-5, 5)
-	expr = (-x).abs()  # | -x |
-	assert expr.eval(assgn(x=-3)) == 3
-	assert expr.eval(assgn(x=4)) == 4
+        x = Var("x") << (-5, 5)
+        expr = (-x).abs()  # | -x |
+        assert expr.eval(assgn(x=-3)) == 3
+        assert expr.eval(assgn(x=4)) == 4
+
+
+def test_builtin_abs_matches_method():
+        x = Var("x") << (-5, 5)
+        y = Var("y") << (-5, 5)
+
+        built = abs(x - y)
+        method = (x - y).abs()
+
+        assert built.eval(assgn(x=2, y=-3)) == method.eval(assgn(x=2, y=-3))
+        assert built.eval(assgn(x=-1, y=4)) == method.eval(assgn(x=-1, y=4))
 
 
 def test_bool_comparisons():


### PR DESCRIPTION
## Summary
- support `abs(expr)` by forwarding to `.abs()`
- expose `__abs__` on `Var`
- test builtin `abs()` forwards correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685751eb807c8327825fc64d54513baa