### PR TITLE
Add unsat explanation feature

### DIFF
--- a/tests/test_unsat_explanations.py
+++ b/tests/test_unsat_explanations.py
@@ -1,0 +1,23 @@
+import pytest
+from logicdsl import LogicSolver, Var, sum_of
+
+
+def test_why_unsat_simple():
+    x = Var("x") << {0, 1}
+    S = LogicSolver()
+    S.require(x == 0, "x_zero")
+    S.require(x == 1, "x_one")
+    with pytest.raises(RuntimeError):
+        S.solve()
+    assert set(S.why_unsat()) == {"x_zero", "x_one"}
+
+
+def test_why_unsat_conflict():
+    x = Var("x") << {0, 1}
+    y = Var("y") << {0, 1}
+    S = LogicSolver()
+    S.require(x == y, "eq")
+    S.require(x != y, "neq")
+    with pytest.raises(RuntimeError):
+        S.solve()
+    assert set(S.why_unsat()) == {"eq", "neq"}


### PR DESCRIPTION
## Summary
- track failing constraint names during search
- add `LogicSolver.why_unsat()` to report unsatisfied constraints after an unsat search
- provide tests for unsat explanations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685758f102ac83279dc84074fc30e877