### PR TITLE
Add let helper for temporary expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,16 @@ q = BoolVar("q")
 rule = when(p).then(q)  # equivalent to p >> q
 ```
 
+### Let Helper
+
+`let(expr).then(lambda t: predicate)` simply passes a temporary expression to
+a lambda function.  This is handy when you want to name an intermediate result
+inside a constraint without creating a separate variable.
+
+```python
+x = Var("x") << (0, 5)
+y = Var("y") << (0, 5)
+
+constraint = let(x + y).then(lambda t: t < 7)
+```
+

--- a/logicdsl/__init__.py
+++ b/logicdsl/__init__.py
@@ -44,6 +44,27 @@ def when(cond: BoolExpr | Var) -> _ImplicationBuilder:
 
 from .solver import LogicSolver, Soft
 
+
+class _LetBuilder:
+        """Helper returned by :func:`let` to pass a temporary expression."""
+
+        def __init__(self, expr: Expr | Var | int | float) -> None:
+                self._expr = Expr._E(expr)
+
+        def then(self, f):
+                """Apply ``f`` to the stored expression and return the result."""
+                return f(self._expr)
+
+
+def let(expr: Expr | Var | int | float) -> _LetBuilder:
+        """Convenience helper for applying a predicate to ``expr``.
+
+        ``let(x + y).then(lambda t: t < 10)`` is equivalent to
+        ``(lambda t: t < 10)(x + y)`` but can improve readability when
+        constructing larger expressions.
+        """
+        return _LetBuilder(expr)
+
 __all__ = [
 	"Var",
 	"BoolVar",
@@ -51,6 +72,7 @@ __all__ = [
         "BoolExpr",
         "named",
         "when",
+        "let",
         # constraints
 	"distinct",
         "at_least_one",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,6 +14,7 @@ from logicdsl import (
         exists,
         forall,
         when,
+        let,
         sum_of,
         product_of,
 	LogicSolver,
@@ -142,6 +143,16 @@ def test_when_then():
         assert implication.satisfied(assgn(p=0, q=0))
         assert implication.satisfied(assgn(p=1, q=1))
         assert not implication.satisfied(assgn(p=1, q=0))
+
+
+def test_let_then():
+        x = Var("x") << (0, 5)
+        y = Var("y") << (0, 5)
+
+        expr = let(x + y).then(lambda t: t < 10)
+
+        assert expr.satisfied(assgn(x=2, y=3))
+        assert not expr.satisfied(assgn(x=6, y=5))
 
 
 


### PR DESCRIPTION
## Summary
- add `let` helper to build expressions via `.then`
- document `let` usage in README
- test the new helper in `test_core.py`

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68582df0f7c08327b58803a033e4b1c4