### PR TITLE
Add Z3 solver backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Install the project in editable mode so that you can run the examples directly:
 
 ```bash
 pip install -e .
+pip install z3-solver
 ```
 
 ## Quick Example
@@ -34,6 +35,21 @@ print(solver.pretty(solution))
 Running the above prints the best assignment of `x` and `y` that sums to 10 while maximizing their product.
 
 Variables do not need to be registered explicitly; the solver automatically discovers all variables that appear in constraints or objectives.
+
+### Z3 Solver
+
+Install `z3-solver` to use the optional backend powered by the Z3 theorem prover:
+
+```python
+from logicdsl import Z3Solver, Var
+
+x = Var("x") << {1, 2, 3}
+y = Var("y") << {1, 2, 3}
+
+solver = Z3Solver()
+solver.require(x + y == 4)
+print(solver.solve())
+```
 
 ### Objective Modes
 

--- a/logicdsl/__init__.py
+++ b/logicdsl/__init__.py
@@ -43,6 +43,7 @@ def when(cond: BoolExpr | Var) -> _ImplicationBuilder:
         return _ImplicationBuilder(BoolExpr._B(cond))
 
 from .solver import LogicSolver, Soft
+from .z3solver import Z3Solver
 
 
 class _LetBuilder:
@@ -86,5 +87,6 @@ __all__ = [
         "product_of",
         # solver
         "LogicSolver",
+        "Z3Solver",
         "Soft",
 ]

--- a/logicdsl/core.py
+++ b/logicdsl/core.py
@@ -156,18 +156,18 @@ class BoolExpr:
 	# --------------------------------------------------------- logic operators
 	def __and__(self, o):
 		o = BoolExpr._B(o)
-		return BoolExpr(lambda a, s=self, t=o: s.satisfied(a) and t.satisfied(a), vars=self._vars | o._vars)
+		return BoolExpr(lambda a, s=self, t=o: s.satisfied(a) & t.satisfied(a), vars=self._vars | o._vars)
 	
 	__rand__ = __and__
 	
 	def __or__(self, o):
 		o = BoolExpr._B(o)
-		return BoolExpr(lambda a, s=self, t=o: s.satisfied(a) or t.satisfied(a), vars=self._vars | o._vars)
+		return BoolExpr(lambda a, s=self, t=o: s.satisfied(a) | t.satisfied(a), vars=self._vars | o._vars)
 	
 	__ror__ = __or__
 	
 	def __invert__(self):
-		return BoolExpr(lambda a, s=self: not s.satisfied(a), vars=self._vars)
+                return BoolExpr(lambda a, s=self: (~s.satisfied(a)) if not isinstance(s.satisfied(a), bool) else (not s.satisfied(a)), vars=self._vars)
 	
 	def __xor__(self, o):
 		o = BoolExpr._B(o)
@@ -176,8 +176,7 @@ class BoolExpr:
 	# implication  (self >> o)
 	def __rshift__(self, o):
 		o = BoolExpr._B(o)
-		return BoolExpr(lambda a, s=self, t=o: (not s.satisfied(a)) or t.satisfied(a), vars=self._vars | o._vars)
-
+		return BoolExpr(lambda a, s=self, t=o: (~s.satisfied(a)) if not isinstance(s.satisfied(a), bool) else (not s.satisfied(a)) | t.satisfied(a), vars=self._vars | o._vars)
 	def named(self, name: str) -> "BoolExpr":
 		"""Return a copy of this BoolExpr with a different name."""
 		return BoolExpr(self._f, name, vars=self._vars)

--- a/logicdsl/z3solver.py
+++ b/logicdsl/z3solver.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import z3
+
+from .core import BoolExpr, Expr, Var
+from .solver import Soft, collect_vars
+
+
+class Z3Solver:
+	"""Z3 backend solver mirroring :class:`LogicSolver`'s API."""
+
+	def __init__(self, objective_mode: str = "lex") -> None:
+		self.vars: List[Var] = []
+		self.hard: List[Tuple[str, BoolExpr]] = []
+		self.soft: List[Soft] = []
+		self.objectives: List[Tuple[Expr, int, float]] = []
+		self.objective_mode = objective_mode
+		if objective_mode not in {"lex", "sum"}:
+			raise ValueError("objective_mode must be 'lex' or 'sum'")
+
+		self._var_is_int: Dict[str, bool] = {}
+
+	def _ensure_vars(self, expr: Expr | BoolExpr) -> None:
+		for v in collect_vars(expr):
+			if v.domain is None:
+				raise ValueError(f"{v.name} missing domain")
+			if v.name not in {x.name for x in self.vars}:
+				self.vars.append(v)
+
+	def add_variables(self, vs: List[Var]) -> None:
+		for v in vs:
+			if v.domain is None:
+				raise ValueError(f"{v.name} missing domain")
+			if v.name not in {x.name for x in self.vars}:
+				self.vars.append(v)
+
+	def require(self, bexp: BoolExpr, name: str | None = None) -> None:
+		self._ensure_vars(bexp)
+		self.hard.append((name or bexp.name, bexp))
+
+	def prefer(self, bexp: BoolExpr, penalty: int = 1, weight: float = 1.0, name: str | None = None) -> None:
+		self._ensure_vars(bexp)
+		self.soft.append(Soft(bexp, penalty, weight, name))
+
+	def maximize(self, expr: Expr, weight: float = 1.0) -> None:
+		self._ensure_vars(expr)
+		self.objectives.append((expr, 1, float(weight)))
+
+	def minimize(self, expr: Expr, weight: float = 1.0) -> None:
+		self._ensure_vars(expr)
+		self.objectives.append((expr, -1, float(weight)))
+
+	def _make_z3_vars(self) -> Dict[str, z3.ExprRef]:
+		mapping: Dict[str, z3.ExprRef] = {}
+		self._var_is_int = {}
+		for v in self.vars:
+			is_int = all(float(val).is_integer() for val in v.domain)
+			self._var_is_int[v.name] = is_int
+			mapping[v.name] = z3.Int(v.name) if is_int else z3.Real(v.name)
+		return mapping
+
+	def _const(self, name: str, val: Any) -> z3.ExprRef:
+		if self._var_is_int.get(name, True):
+			return z3.IntVal(int(val))
+		return z3.RealVal(float(val))
+
+	def _model_value(self, model: z3.ModelRef, expr: z3.ExprRef) -> Any:
+		val = model.eval(expr, model_completion=True)
+		if isinstance(val, z3.IntNumRef):
+			return val.as_long()
+		if isinstance(val, z3.RatNumRef):
+			num = val.numerator_as_long()
+			den = val.denominator_as_long()
+			return num / den
+		return val
+
+	def _build_penalty_expr(self, env: Dict[str, z3.ExprRef]) -> z3.ArithRef:
+		terms = [z3.If(s.bexp.satisfied(env), 0, s.penalty) for s in self.soft]
+		return z3.Sum(terms) if terms else z3.IntVal(0)
+
+	def _build_objective_expr(self, env: Dict[str, z3.ExprRef]) -> z3.ArithRef:
+		parts = [weight * sense * expr.eval(env) for expr, sense, weight in self.objectives]
+		soft_parts = [s.weight * z3.If(s.bexp.satisfied(env), 0, s.penalty) for s in self.soft]
+		obj = z3.Sum(parts) if parts else z3.IntVal(0)
+		soft = z3.Sum(soft_parts) if soft_parts else z3.IntVal(0)
+		return obj - soft
+
+	def _domain_constraints(self, env: Dict[str, z3.ExprRef]) -> List[z3.BoolRef]:
+		cons = []
+		for v in self.vars:
+			var = env[v.name]
+			vals = [self._const(v.name, d) for d in v.domain]
+			cons.append(z3.Or([var == c for c in vals]))
+		return cons
+
+	def solve(self, timeout: float | None = None) -> Dict[str, Any]:
+		zvars = self._make_z3_vars()
+		env = {k: v for k, v in zvars.items()}
+		penalty_expr = self._build_penalty_expr(env)
+		opt = z3.Optimize()
+		if timeout is not None:
+			opt.set(timeout=int(timeout * 1000))
+
+		for c in self._domain_constraints(env):
+			opt.add(c)
+		for _, bexp in self.hard:
+			opt.add(bexp.satisfied(env))
+
+		opt.minimize(penalty_expr)
+
+		if self.objective_mode == "sum":
+			obj_expr = self._build_objective_expr(env)
+			opt.maximize(obj_expr)
+		else:
+			for expr, sense, _ in self.objectives:
+				val = expr.eval(env)
+				if sense == 1:
+					opt.maximize(val)
+				else:
+					opt.minimize(val)
+
+		if opt.check() != z3.sat:
+			raise RuntimeError("No feasible solution")
+
+		model = opt.model()
+		assignment = {v.name: self._model_value(model, zvars[v.name]) for v in self.vars}
+		penalty_val = self._model_value(model, penalty_expr)
+
+		result = {"assignment": assignment, "penalty": int(penalty_val)}
+		if self.objectives:
+			if self.objective_mode == "sum":
+				obj_val = self._model_value(model, obj_expr)
+				result["objective"] = float(obj_val)
+			else:
+				vals = [self._model_value(model, expr.eval(env)) for expr, _, _ in self.objectives]
+				result["objectives"] = [float(v) if isinstance(v, float) else int(v) for v in vals]
+		return result
+
+	def all_solutions(self, limit: int | None = None, timeout: float | None = None) -> List[Dict[str, Any]]:
+		zvars = self._make_z3_vars()
+		env = {k: v for k, v in zvars.items()}
+		solver = z3.Solver()
+		if timeout is not None:
+			solver.set(timeout=int(timeout * 1000))
+
+		for c in self._domain_constraints(env):
+			solver.add(c)
+		for _, bexp in self.hard:
+			solver.add(bexp.satisfied(env))
+
+		solutions: List[Dict[str, Any]] = []
+
+		while True:
+			if limit is not None and len(solutions) >= limit:
+				break
+			if solver.check() != z3.sat:
+				break
+			model = solver.model()
+			assign = {v.name: self._model_value(model, zvars[v.name]) for v in self.vars}
+			penalty = sum(s.cost(assign) for s in self.soft)
+			if self.objective_mode == "sum":
+				obj = sum(weight * sense * expr.eval(assign) for expr, sense, weight in self.objectives) - sum(
+					s.weight * s.cost(assign) for s in self.soft
+				)
+				entry = {"assignment": assign, "penalty": penalty, "objective": obj}
+			else:
+				objs = [sense * expr.eval(assign) for expr, sense, _ in self.objectives]
+				entry = {"assignment": assign, "penalty": penalty, "objectives": objs}
+			solutions.append(entry)
+
+			# block this assignment
+			solver.add(z3.Or([zvars[name] != self._const(name, val) for name, val in assign.items()]))
+
+		return solutions
+
+	@staticmethod
+	def _pretty_dict(d: Dict[str, Any]) -> str:
+		return "\n".join(f"{k:>10} : {v}" for k, v in sorted(d.items()))
+
+	def pretty(self, sol: Dict[str, Any]) -> str:
+		rows = [self._pretty_dict(sol["assignment"])]
+		rows.append(f"  penalty : {sol['penalty']}")
+		if self.objectives:
+			if self.objective_mode == "sum":
+				rows.append(f"  objective : {sol['objective']}")
+			else:
+				rows.append(f" objectives : {tuple(sol['objectives'])}")
+		return "\n".join(rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = "A tiny Python DSL for finite-domain logic solving"
 authors = [{ name = "Alan Bagel", email = "jiuprogrammer@gmail.com" }]
 readme = "README.md"
 requires-python = ">=3.10"
+dependencies = [
+        "z3-solver",
+]
 
 [build-system]
 requires = ["setuptools>=67", "wheel"]

--- a/tests/test_z3solver.py
+++ b/tests/test_z3solver.py
@@ -1,0 +1,29 @@
+import pytest
+
+from logicdsl import Var, sum_of, product_of, LogicSolver, Z3Solver
+
+
+@pytest.mark.parametrize("Solver", [LogicSolver, Z3Solver])
+def test_basic_solution(Solver):
+ x = Var("x") << (1, 9)
+ y = Var("y") << {2, 4, 6, 8}
+ S = Solver()
+ S.require(sum_of([x, y]) == 10)
+ S.maximize(product_of([x, y]))
+ sol = S.solve()
+ values = sol["assignment"]
+ assert values in ({"x": 4, "y": 6}, {"x": 6, "y": 4})
+ assert sol["penalty"] == 0
+
+
+@pytest.mark.parametrize("Solver", [LogicSolver, Z3Solver])
+def test_all_solutions_limit(Solver):
+ x = Var("x") << (1, 3)
+ y = Var("y") << (1, 3)
+ S = Solver()
+ S.require(sum_of([x, y]) == 4)
+ sols = S.all_solutions(limit=2)
+ assert len(sols) == 2
+ assigns = [s["assignment"] for s in sols]
+ for a in assigns:
+     assert a["x"] + a["y"] == 4


### PR DESCRIPTION
## Summary
- add z3-solver dependency
- implement `Z3Solver` with Z3 backend
- re-export `Z3Solver`
- document Z3 solver usage
- provide tests using both solvers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685837cbf04c832784e09e0ff829e811