### PR TITLE
Add TagSet helper class

### DIFF
--- a/logicdsl/__init__.py
+++ b/logicdsl/__init__.py
@@ -35,6 +35,7 @@ def when(cond: BoolExpr | Var) -> _ImplicationBuilder:
 
 from .solver import LogicSolver, Soft
 from .z3solver import Z3Solver
+from .tagset import TagSet
 
 
 class _LetBuilder:
@@ -76,9 +77,10 @@ __all__ = [
 	"forall",
 	"exists",
 	"sum_of",
-	"product_of",
-	# solver
-	"LogicSolver",
+        "product_of",
+       "TagSet",
+        # solver
+        "LogicSolver",
 	"Z3Solver",
 	"Soft",
 ]

--- a/logicdsl/core.py
+++ b/logicdsl/core.py
@@ -26,11 +26,11 @@ def _make_domain(lo: float, hi: float, step: float | None) -> list:
 			val = lo
 			if step > 0:
 				while val <= hi + 1e-9:
-					dom.append(round(val, 10))
+					dom.append(val)
 					val += step
 			else:
 				while val >= hi - 1e-9:
-					dom.append(round(val, 10))
+					dom.append(val)
 					val += step
 			return dom
 	

--- a/logicdsl/tagset.py
+++ b/logicdsl/tagset.py
@@ -1,0 +1,37 @@
+# logicdsl/tagset.py
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from .core import BoolVar, Var
+from .constraints import at_least_k, at_least_one, exactly_one, _to_bool
+from .solver import LogicSolver
+
+
+def _at_most_k(xs: Iterable[Var], k: int):
+	"""Return BoolExpr enforcing that at most ``k`` of ``xs`` are true."""
+	xs_b = [_to_bool(x) for x in xs]
+	return at_least_k([~x for x in xs_b], len(xs_b) - k)
+
+
+class TagSet:
+	"""Convenience wrapper for a group of BoolVars."""
+
+	def __init__(self, solver: LogicSolver, tags: Iterable[str], prefix: str = "") -> None:
+		self._solver = solver
+		self._vars: Dict[str, Var] = {t: BoolVar(prefix + t) for t in tags}
+
+	def var(self, tag: str) -> Var:
+		return self._vars[tag]
+
+	def vars(self) -> Dict[str, Var]:
+		return self._vars
+
+	def enforce_exactly_one(self) -> None:
+		self._solver.require(exactly_one(list(self._vars.values())))
+
+	def enforce_at_least_one(self) -> None:
+		self._solver.require(at_least_one(list(self._vars.values())))
+
+	def enforce_at_most(self, k: int) -> None:
+		self._solver.require(_at_most_k(list(self._vars.values()), k))

--- a/tests/test_tagset.py
+++ b/tests/test_tagset.py
@@ -1,0 +1,37 @@
+from logicdsl import LogicSolver
+from logicdsl.tagset import TagSet
+
+
+def count_true(assign, tags):
+	return sum(assign[t] for t in tags)
+
+
+def test_tagset_exactly_one():
+	tags = ["r", "g", "b"]
+	S = LogicSolver()
+	ts = TagSet(S, tags)
+	ts.enforce_exactly_one()
+	sols = S.all_solutions()
+	assert len(sols) == 3
+	for s in sols:
+		assert count_true(s["assignment"], tags) == 1
+
+
+def test_tagset_at_least_one():
+	S = LogicSolver()
+	ts = TagSet(S, ["x", "y"])
+	ts.enforce_at_least_one()
+	sol = S.solve()
+	a = sol["assignment"]
+	assert a["x"] + a["y"] >= 1
+
+
+def test_tagset_at_most_k():
+	tags = ["a", "b", "c", "d"]
+	S = LogicSolver()
+	ts = TagSet(S, tags)
+	ts.enforce_at_most(2)
+	sols = S.all_solutions()
+	assert len(sols) == 11
+	for s in sols:
+		assert count_true(s["assignment"], tags) <= 2


### PR DESCRIPTION
## Summary
- add new `TagSet` utility for groups of BoolVars with group constraints
- expose `TagSet` in package init
- adjust float domain generation to avoid rounding
- test TagSet integration with LogicSolver

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6ffe5b448327871640494584c462