### PR TITLE
Add require_all for bulk constraints

### DIFF
--- a/logicdsl/solver.py
+++ b/logicdsl/solver.py
@@ -71,6 +71,11 @@ class LogicSolver:
 	def require(self, bexp: BoolExpr, name: str | None = None) -> None:
 		self._ensure_vars(bexp)
 		self.hard.append((name or bexp.name, bexp))
+
+	def require_all(self, pred, vs) -> None:
+		"""Apply ``pred`` to each variable and add the resulting constraints."""
+		for v in vs:
+			self.require(pred(v))
 	
 	def prefer(self, bexp: BoolExpr, penalty: int = 1, weight: float = 1.0, name: str | None = None) -> None:
 		self._ensure_vars(bexp)

--- a/logicdsl/z3solver.py
+++ b/logicdsl/z3solver.py
@@ -42,6 +42,11 @@ class Z3Solver:
         self._ensure_vars(bexp)
         self.hard.append((name or bexp.name, bexp))
 
+    def require_all(self, pred, vs) -> None:
+        """Apply ``pred`` to each variable and add the resulting constraints."""
+        for v in vs:
+            self.require(pred(v))
+
     def prefer(self, bexp: BoolExpr, penalty: int = 1, weight: float = 1.0, name: str | None = None) -> None:
         self._ensure_vars(bexp)
         self.soft.append(Soft(bexp, penalty, weight, name))

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -178,3 +178,14 @@ def test_all_solutions_timeout_returns_partial():
 	
 	sols = S.all_solutions(timeout=0.0)
 	assert sols == []
+
+
+def test_require_all():
+	xs = [Var(f"x{i}") << (0, 3) for i in range(3)]
+
+	S = LogicSolver()
+	S.require_all(lambda v: v < 2, xs)
+	S.require(sum_of(xs) == 3)
+
+	sol = S.solve()
+	assert sol["assignment"] == {f"x{i}": 1 for i in range(3)}


### PR DESCRIPTION
## Summary
- extend LogicSolver with `require_all`
- extend Z3Solver with `require_all`
- test new method in solver tests

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c80519a0883279be0fd102f76604f